### PR TITLE
fix(sip): resolve dual receiver loop packet loss race condition

### DIFF
--- a/src-tauri/src/infrastructure/sip/listener.rs
+++ b/src-tauri/src/infrastructure/sip/listener.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 /// Extract From tag from From header
-fn extract_from_tag(from_header: &str) -> Option<String> {
+pub(crate) fn extract_from_tag(from_header: &str) -> Option<String> {
     if let Some(tag_part) = from_header.split("tag=").nth(1) {
         let tag = tag_part.split(';').next().map(|s| s.trim().to_string());
         if let Some(t) = tag {
@@ -25,7 +25,7 @@ fn extract_from_tag(from_header: &str) -> Option<String> {
 }
 
 /// Extract Request-URI from a SIP request message
-fn extract_request_uri(message: &SipMessage) -> Result<String, SipError> {
+pub(crate) fn extract_request_uri(message: &SipMessage) -> Result<String, SipError> {
     match message {
         SipMessage::Request(_request) => {
             // The request URI is in the request line
@@ -51,7 +51,7 @@ fn extract_request_uri(message: &SipMessage) -> Result<String, SipError> {
 }
 
 /// Extract Via header from a SIP message
-fn extract_via_header(message: &SipMessage) -> Result<String, SipError> {
+pub(crate) fn extract_via_header(message: &SipMessage) -> Result<String, SipError> {
     let message_bytes: Vec<u8> = message.clone().into();
     let message_str = String::from_utf8_lossy(&message_bytes);
 
@@ -73,7 +73,7 @@ fn extract_via_header(message: &SipMessage) -> Result<String, SipError> {
 }
 
 /// Extract CSeq header from a SIP message
-fn extract_cseq_header(message: &SipMessage) -> Result<String, SipError> {
+pub(crate) fn extract_cseq_header(message: &SipMessage) -> Result<String, SipError> {
     let message_bytes: Vec<u8> = message.clone().into();
     let message_str = String::from_utf8_lossy(&message_bytes);
 
@@ -95,7 +95,7 @@ fn extract_cseq_header(message: &SipMessage) -> Result<String, SipError> {
 }
 
 /// Extract SDP body from a SIP message if present
-fn extract_sdp_body(message: &SipMessage) -> Option<String> {
+pub(crate) fn extract_sdp_body(message: &SipMessage) -> Option<String> {
     // Convert SipMessage to bytes
     let message_bytes: Vec<u8> = message.clone().into();
     let message_str = String::from_utf8_lossy(&message_bytes);

--- a/src-tauri/src/infrastructure/sip/message_receiver.rs
+++ b/src-tauri/src/infrastructure/sip/message_receiver.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 /// Extract status code from a SIP response message
-fn extract_status_code(message: &SipMessage) -> Result<u16, SipError> {
+pub(crate) fn extract_status_code(message: &SipMessage) -> Result<u16, SipError> {
     match message {
         SipMessage::Response(response) => {
             let status_str = response.status_code.to_string();
@@ -31,7 +31,7 @@ fn extract_status_code(message: &SipMessage) -> Result<u16, SipError> {
 }
 
 /// Extract SDP body from a SIP message if present
-fn extract_sdp_body(message: &SipMessage) -> Option<String> {
+pub(crate) fn extract_sdp_body(message: &SipMessage) -> Option<String> {
     // Convert SipMessage to bytes
     let message_bytes: Vec<u8> = message.clone().into();
     let message_str = String::from_utf8_lossy(&message_bytes);

--- a/src-tauri/src/infrastructure/sip/mod.rs
+++ b/src-tauri/src/infrastructure/sip/mod.rs
@@ -12,6 +12,7 @@ pub mod registration;
 pub mod sdp;
 pub mod tls;
 pub mod transport;
+pub mod unified_receiver;
 
 pub use client::{SipClient, TransportType};
 pub use headers::{extract_call_id_header, extract_from_header, extract_to_header};
@@ -28,3 +29,4 @@ pub use sdp::{
 };
 pub use tls::{create_tls_config, extract_hostname_from_credentials, extract_hostname_from_uri};
 pub use transport::{SipTransport, TcpTransport, TlsTransport, UdpTransport};
+pub use unified_receiver::start_unified_receiver;

--- a/src-tauri/src/infrastructure/sip/unified_receiver.rs
+++ b/src-tauri/src/infrastructure/sip/unified_receiver.rs
@@ -1,0 +1,282 @@
+// Unified SIP message receiver
+// Single receiver loop that demultiplexes messages to appropriate handlers
+// Fixes race condition where two separate loops competed for the same socket
+
+use crate::domain::errors::SipError;
+use crate::infrastructure::sip::client::SipClient;
+use crate::infrastructure::sip::headers::{
+    extract_call_id_header, extract_from_header, extract_to_header,
+};
+use crate::infrastructure::sip::listener::{
+    extract_cseq_header, extract_from_tag, extract_request_uri,
+    extract_sdp_body as extract_sdp_body_listener, extract_via_header,
+};
+use crate::infrastructure::sip::message_receiver::{
+    extract_sdp_body as extract_sdp_body_receiver, extract_status_code,
+};
+use crate::services::call_service::CallService;
+use rsip::SipMessage;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Start the unified message receiver loop
+///
+/// This function runs in an infinite loop, continuously receiving SIP messages
+/// from the SIP client and demultiplexing them to appropriate handlers:
+/// - INVITE requests → handle_incoming_invite()
+/// - Response messages → handle_invite_response()
+/// - Other messages → logged and skipped
+///
+/// This fixes the race condition where two separate loops competed for the same socket,
+/// causing packet loss when messages were consumed by the wrong loop.
+///
+/// # Arguments
+/// * `sip_client` - Arc<Mutex<SipClient>> for receiving messages
+/// * `call_service` - Arc<Mutex<CallService>> for handling messages
+pub async fn start_unified_receiver(
+    sip_client: Arc<Mutex<SipClient>>,
+    call_service: Arc<Mutex<CallService>>,
+) {
+    eprintln!("DEBUG:[UNIFIED_RECEIVER/START] Starting unified message receiver loop");
+
+    loop {
+        // Receive message from SIP client (single point of reception)
+        let result = {
+            let mut client = sip_client.lock().await;
+            client.receive_message().await
+        };
+
+        match result {
+            Ok((message, source_addr)) => {
+                eprintln!("DEBUG:[UNIFIED_RECEIVER/RECEIVE] Received SIP message");
+
+                // Demultiplex based on message type
+                match &message {
+                    // Handle INVITE requests
+                    SipMessage::Request(request)
+                        if request.method.to_string().to_uppercase() == "INVITE" =>
+                    {
+                        eprintln!(
+                            "DEBUG:[UNIFIED_RECEIVER/DEMUX] Routing INVITE request to handler"
+                        );
+                        if let Err(e) =
+                            handle_invite_request(&message, source_addr, &call_service).await
+                        {
+                            eprintln!(
+                                "DEBUG:[UNIFIED_RECEIVER/HANDLE] Failed to handle INVITE request: {}",
+                                e
+                            );
+                            // Continue loop despite error
+                        }
+                    }
+                    // Handle response messages
+                    SipMessage::Response(_) => {
+                        eprintln!("DEBUG:[UNIFIED_RECEIVER/DEMUX] Routing response to handler");
+                        if let Err(e) = handle_response(&message, &call_service).await {
+                            eprintln!(
+                                "DEBUG:[UNIFIED_RECEIVER/HANDLE] Failed to handle response: {}",
+                                e
+                            );
+                            // Continue loop despite error
+                        }
+                    }
+                    // Other requests (ACK, BYE, etc.) - log and skip for now
+                    SipMessage::Request(req) => {
+                        eprintln!(
+                            "DEBUG:[UNIFIED_RECEIVER/DEMUX] Skipping non-INVITE request: {}",
+                            req.method
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!(
+                    "DEBUG:[UNIFIED_RECEIVER/RECEIVE] Error receiving message: {}",
+                    e
+                );
+                // Continue loop despite error
+            }
+        }
+    }
+}
+
+/// Handle an incoming INVITE request
+async fn handle_invite_request(
+    message: &SipMessage,
+    source_addr: SocketAddr,
+    call_service: &Arc<Mutex<CallService>>,
+) -> Result<(), SipError> {
+    eprintln!("DEBUG:[UNIFIED_RECEIVER/INVITE] Processing INVITE request");
+
+    // Extract Call-ID header
+    let call_id_header = extract_call_id_header(message)?;
+    eprintln!(
+        "DEBUG:[UNIFIED_RECEIVER/INVITE] Extracted Call-ID: {}",
+        call_id_header
+    );
+
+    // Extract From header
+    let from_header = extract_from_header(message)?;
+    eprintln!(
+        "DEBUG:[UNIFIED_RECEIVER/INVITE] Extracted From: {}",
+        from_header
+    );
+
+    // Extract From tag
+    let from_tag = extract_from_tag(&from_header);
+    if from_tag.is_some() {
+        eprintln!(
+            "DEBUG:[UNIFIED_RECEIVER/INVITE] Extracted From tag: {}",
+            from_tag.as_ref().unwrap()
+        );
+    } else {
+        eprintln!("DEBUG:[UNIFIED_RECEIVER/INVITE] Warning: From tag not found");
+    }
+
+    // Extract To header
+    let to_header = extract_to_header(message)?;
+    eprintln!(
+        "DEBUG:[UNIFIED_RECEIVER/INVITE] Extracted To: {}",
+        to_header
+    );
+
+    // Extract Request-URI (remote number)
+    let remote_uri = extract_request_uri(message)?;
+    eprintln!(
+        "DEBUG:[UNIFIED_RECEIVER/INVITE] Extracted Request-URI: {}",
+        remote_uri
+    );
+
+    // Extract SDP body (if present)
+    let sdp_body = extract_sdp_body_listener(message);
+    if sdp_body.is_some() {
+        eprintln!("DEBUG:[UNIFIED_RECEIVER/INVITE] Extracted SDP body");
+    }
+
+    // Extract Via header (needed for 100 Trying response)
+    let via_header = extract_via_header(message)?;
+    eprintln!(
+        "DEBUG:[UNIFIED_RECEIVER/INVITE] Extracted Via: {}",
+        via_header
+    );
+
+    // Extract CSeq header (needed for 100 Trying response)
+    let cseq_header = extract_cseq_header(message)?;
+    eprintln!(
+        "DEBUG:[UNIFIED_RECEIVER/INVITE] Extracted CSeq: {}",
+        cseq_header
+    );
+
+    // Route to CallService.handle_incoming_invite()
+    let result = {
+        let service = call_service.lock().await;
+        service
+            .handle_incoming_invite(
+                &call_id_header,
+                from_tag.as_deref(),
+                &from_header,
+                &to_header,
+                &remote_uri,
+                sdp_body.as_deref(),
+                &via_header,
+                &cseq_header,
+                source_addr,
+            )
+            .await
+    };
+
+    match result {
+        Ok(call_id) => {
+            eprintln!(
+                "DEBUG:[UNIFIED_RECEIVER/INVITE] Successfully handled incoming INVITE, created call: {}",
+                call_id.as_str()
+            );
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!(
+                "DEBUG:[UNIFIED_RECEIVER/INVITE] Failed to handle incoming INVITE: {}",
+                e
+            );
+            Err(e)
+        }
+    }
+}
+
+/// Handle a SIP response message
+async fn handle_response(
+    message: &SipMessage,
+    call_service: &Arc<Mutex<CallService>>,
+) -> Result<(), SipError> {
+    eprintln!("DEBUG:[UNIFIED_RECEIVER/RESPONSE] Processing response message");
+
+    // Extract Call-ID header
+    let call_id_header = extract_call_id_header(message)?;
+    eprintln!(
+        "DEBUG:[UNIFIED_RECEIVER/RESPONSE] Extracted Call-ID: {}",
+        call_id_header
+    );
+
+    // Extract status code
+    let status_code = extract_status_code(message)?;
+    eprintln!(
+        "DEBUG:[UNIFIED_RECEIVER/RESPONSE] Extracted status code: {}",
+        status_code
+    );
+
+    // Extract SDP body (if present)
+    let sdp_body = extract_sdp_body_receiver(message);
+    if sdp_body.is_some() {
+        eprintln!("DEBUG:[UNIFIED_RECEIVER/RESPONSE] Extracted SDP body");
+    }
+
+    // Find call by Call-ID header
+    let call_id_opt = {
+        let service = call_service.lock().await;
+        service.find_call_by_call_id_header(&call_id_header).await
+    };
+
+    match call_id_opt {
+        Some(call_id) => {
+            eprintln!(
+                "DEBUG:[UNIFIED_RECEIVER/RESPONSE] Matched Call-ID to call: {}",
+                call_id.as_str()
+            );
+
+            // Route to CallService.handle_invite_response()
+            let result = {
+                let service = call_service.lock().await;
+                service
+                    .handle_invite_response(&call_id, status_code, sdp_body.as_deref())
+                    .await
+            };
+
+            match result {
+                Ok(()) => {
+                    eprintln!(
+                        "DEBUG:[UNIFIED_RECEIVER/RESPONSE] Successfully handled response for call: {}",
+                        call_id.as_str()
+                    );
+                    Ok(())
+                }
+                Err(e) => {
+                    eprintln!(
+                        "DEBUG:[UNIFIED_RECEIVER/RESPONSE] Failed to handle response for call {}: {}",
+                        call_id.as_str(),
+                        e
+                    );
+                    Err(e)
+                }
+            }
+        }
+        None => {
+            eprintln!(
+                "DEBUG:[UNIFIED_RECEIVER/RESPONSE] No active call found for Call-ID: {}",
+                call_id_header
+            );
+            // This might be a response for a call that already ended - not an error
+            Ok(())
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,8 +24,7 @@ use commands::{
 use domain::traits::CredentialStore;
 use infrastructure::audio::create_audio_engine;
 use infrastructure::sip::client::SipClient;
-use infrastructure::sip::listener;
-use infrastructure::sip::message_receiver;
+use infrastructure::sip::unified_receiver;
 #[cfg(target_os = "macos")]
 use infrastructure::storage::KeychainCredentialStore;
 use services::AudioService;
@@ -118,31 +117,21 @@ pub fn run() {
                 event_emitter,
             );
 
-            // Get references for message receiver before managing app_state
+            // Get references for unified receiver before managing app_state
             let call_service = Arc::clone(&app_state.call_service);
 
             app.manage(app_state);
 
-            // Spawn message receiver background task
-            eprintln!("DEBUG:[SETUP] Spawning message receiver background task");
+            // Spawn unified message receiver background task
+            // This single receiver demultiplexes messages to appropriate handlers,
+            // fixing the race condition where two separate loops competed for the same socket
+            eprintln!("DEBUG:[SETUP] Spawning unified message receiver background task");
             let call_client_for_receiver_clone = Arc::clone(&call_client_for_receiver);
             let call_service_for_receiver = Arc::clone(&call_service);
             rt_handle.spawn(async move {
-                message_receiver::start_message_receiver(
+                unified_receiver::start_unified_receiver(
                     call_client_for_receiver_clone,
                     call_service_for_receiver,
-                )
-                .await;
-            });
-
-            // Spawn INVITE listener background task
-            eprintln!("DEBUG:[SETUP] Spawning INVITE listener background task");
-            let call_client_for_listener = Arc::clone(&call_client_for_receiver);
-            let call_service_for_listener = Arc::clone(&call_service);
-            rt_handle.spawn(async move {
-                listener::start_invite_listener(
-                    call_client_for_listener,
-                    call_service_for_listener,
                 )
                 .await;
             });


### PR DESCRIPTION
## Summary

This PR fixes a critical race condition in the SIP message receiver implementation where two separate loops (`message_receiver` and `invite_listener`) were competing for messages from the same `SipClient` socket, causing packet loss.

## Changes

- **Created unified message receiver**: Single `unified_receiver` module that receives all messages from one loop
- **Demultiplexing logic**: Routes INVITE requests to `handle_incoming_invite()` and responses to `handle_invite_response()`
- **Exported helper functions**: Made extraction functions in `listener.rs` and `message_receiver.rs` public for reuse
- **Updated lib.rs**: Replaced two competing loops with single unified receiver

## Problem Fixed

Previously, both loops would call `receive_message()` on the same `SipClient` instance:
- Whichever loop acquired the lock first would receive the packet
- The other loop would never see that packet (UDP sockets consume packets)
- This caused random failures:
  - INVITE requests consumed by `message_receiver` (which only handles responses) → dropped
  - Response messages consumed by `invite_listener` (which only handles INVITEs) → dropped

## Solution

A single receiver loop now:
1. Receives all messages from the socket (no competition)
2. Demultiplexes based on message type:
   - `SipMessage::Request` with method "INVITE" → route to invite handler
   - `SipMessage::Response` → route to response handler
   - Other requests → logged and skipped

## Testing

### How to Test

1. **Setup**:
   ```bash
   git checkout fix/dual-receiver-packet-loss
   cd src-tauri
   cargo build
   ```

2. **Test Steps**:
   - Register a SIP account
   - Make an outbound call (should receive 200 OK response)
   - Receive an inbound call (should receive INVITE request)
   - Verify both call flows complete successfully

3. **Expected Behavior**:
   - All SIP messages are received and processed correctly
   - No packet loss or dropped messages
   - Calls complete successfully in both directions
   - No race condition errors in logs

### Test Coverage

- [x] Code compiles successfully
- [x] Rust formatting and linting pass
- [ ] Manual testing with real SIP server (recommended)
- [ ] Integration tests (if available)

## Review Checklist

### Code Quality

- [x] Code follows project conventions
- [x] Functions are focused and single-purpose
- [x] Variable names are descriptive
- [x] No code duplication
- [x] Error handling is appropriate

### Framework Compliance

- [x] Rust code follows idiomatic patterns
- [x] Tauri IPC follows best practices
- [x] Async/await used correctly

### Security

- [x] No hardcoded secrets
- [x] Input validation present (SIP message parsing)
- [x] Error messages don't leak sensitive data

### Documentation

- [x] Code comments explain the fix
- [x] Commit message describes the problem and solution

## Breaking Changes

None - this is a bug fix that maintains the same API.

## Related Issues

Fixes the race condition identified in code review feedback:
- Dual receiver loops competing for the same socket
- Packet loss causing random call failures

## Additional Notes

- The old `start_message_receiver()` and `start_invite_listener()` functions are still in the codebase but are no longer used
- They could be removed in a future cleanup PR if desired
- All helper functions are now properly exported for reuse
